### PR TITLE
Fix version conflict git / git-svn

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -22,7 +22,9 @@ jobs:
 
       - name: install git-svn package
         run: |
+          sudo apt-get remove git git-man
           sudo apt-get update
+          sudo apt-get install git=1:2.25.1-1ubuntu3.1  --no-install-recommends
           sudo apt-get install git-svn --no-install-recommends
 
       - name: checkout mirror config branch

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -24,7 +24,6 @@ jobs:
         run: |
           sudo apt-get remove git git-man
           sudo apt-get update
-          sudo apt-get install git=1:2.25.1-1ubuntu3.1  --no-install-recommends
           sudo apt-get install git-svn --no-install-recommends
 
       - name: checkout mirror config branch


### PR DESCRIPTION
git-svn isn't able to work with the up to date git wich is installed from a ppa repository

`The following packages have unmet dependencies:
 git-svn : Depends: git (< 1:2.25.1-.) but 1:2.31.1-0ppa1~ubuntu20.04.1 is to be installed`

- Remove installed version of `git` and `git-man` and then let git-svn install a compatible version of `git`